### PR TITLE
Init PCA10059

### DIFF
--- a/config/pca10059-dongle/CMakeBuild.config
+++ b/config/pca10059-dongle/CMakeBuild.config
@@ -1,0 +1,159 @@
+########################################################################################################################
+# Configuration options, used by build systems and scripts.
+########################################################################################################################
+#
+# The configuration settings that are used for releases are set in:
+#    source/conf/cmake/CMakeBuild.config.default
+#
+# The default settings here are for development. The settings of CMakeBuild.config.default will be overwritten.
+#
+# If you want other settings on your system, do not just this file (it will be commited to the code repository).
+#
+# Recommended:
+#
+#   + Add the custom settings to a new file in this directory: config/default/CMakeBuild.overwrite.config
+#     + If those are runtime settings, you can also use: config/default/CMakeBuild.runtime.config
+#     + Run cmake and make with the default target.
+#   + Add a new directory in config, say config/feature
+#     + Copy this file to that directory and change whatever you like.
+#     + No need to commit this new directory to git, feel free again to use overwrite and runtime config.
+#     + Run cmake and make with the new target (here called feature).
+#
+
+# The name that is advertised for this target. Should be 4 characters or less.
+BLUETOOTH_NAME=CR40
+
+# By default, a Crownstone has its serial disabled, which can be enabled via a bluetooth command.
+# You can change the default value:
+CS_SERIAL_ENABLED=SERIAL_ENABLE_RX_AND_TX
+
+# Set the log level.
+# A complete list of options can be found in CMakeBuild.config.default
+# Always check if you can compile with maximum verbosity: SERIAL_DEBUG.
+SERIAL_VERBOSITY=SERIAL_INFO
+
+# Enable the binary protocol if you want to use a UART library.
+# Disable the binary protocol if you want to use a serial communication program, like minicom.
+#CS_UART_BINARY_PROTOCOL_ENABLED=1
+CS_UART_BINARY_PROTOCOL_ENABLED=0
+
+# Enable microapps
+BUILD_MICROAPP_SUPPORT=1
+
+# Automatically enable microapp on boot
+AUTO_ENABLE_MICROAPP_ON_BOOT=1
+
+# Enable gpio
+BUILD_GPIOTE=1
+
+GPIO_PIN1_INDEX=0
+GPIO_PIN2_INDEX=1
+GPIO_PIN3_INDEX=2
+GPIO_PIN4_INDEX=3
+
+BUTTON1_INDEX=0
+BUTTON2_INDEX=1
+BUTTON3_INDEX=2
+BUTTON4_INDEX=3
+
+LED1_INDEX=0
+LED2_INDEX=1
+LED3_INDEX=2
+LED4_INDEX=3
+
+########################################################################################################################
+# Settings for the nRF52840
+# See CMakeBuild.config.default for explanation.
+########################################################################################################################
+
+# The hardware board where you want to upload the firmware
+# For the complete overview of the hardware boards, see CMakeBuild.config.default
+HARDWARE_BOARD=PCA10059
+
+# The hardware board as defined within the Nordic code (e.g. for internal pin layout).
+NORDIC_HARDWARE_BOARD=PCA10059
+
+# The device itself (should be removed)
+DEVICE=nRF52840_xxAA
+
+# The particular Nordic device. 
+# See https://infocenter.nordicsemi.com/topic/ps_nrf52840/memory.html.
+# It has 1024 kB flash and 256 kB of ram.
+NRF_DEVICE=NRF52840_XXAA
+
+# The device type without specific hardware series suffix
+NRF_DEVICE_TYPE=NRF52840
+
+# The total amount of flash for the nRF52840-QFAA (1 MB)
+TOTAL_AMOUNT_FLASH=0x100000
+
+# The total amount of ram for the nRF52840-QFAA (256 kB)
+TOTAL_AMOUNT_RAM=0x40000
+
+# We are using SDK version 17
+NORDIC_SDK_VERSION=17
+
+# Specify the Nordic SDK version in more detail
+NORDIC_SDK_VERSION_MAJOR=17
+NORDIC_SDK_VERSION_MINOR=1
+NORDIC_SDK_VERSION_PATCH=0
+
+# Specify the Mesh SDK version
+MESH_SDK_VERSION_MAJOR=5
+MESH_SDK_VERSION_MINOR=0
+MESH_SDK_VERSION_PATCH=0
+
+# This SDK comes with Softdevice 7.2.0, check for documentation
+# bluenet/tools/nrf5_sdk/components/softdevice/s132/doc/s132_nrf52_7.2.0_release-notes.pdf
+# bluenet/tools/nrf5_sdk/components/softdevice/s132/doc/s132_nrf52_7.2.0_migration-document.pdf
+# Details:
+#   Uses MBR version 2.4.1
+#   Combined MBR & SoftDevice memory requirements
+#     Flash: 152 kB (0x26000 bytes)
+#     Ram: 5.6 kB (0x1668 bytes)
+#     Call stack: worst-case 1.75 kB (0x700 byte) and is co-shared with the application.
+#   Firmware id: 0x0101
+SOFTDEVICE_MAJOR=7
+SOFTDEVICE_MINOR=2
+SOFTDEVICE_SERIES=132
+SOFTDEVICE=s132_nrf52_7.2.0
+
+# The number of pages reserved before FDS for possible FDS expansion in the future
+# On the nRF52832 the microapp size is 2 pages.
+# On the nRF52840 we have more pages, so lets reserve some more.
+CS_FDS_VIRTUAL_PAGES_RESERVED_BEFORE=8
+
+# The microapp located before FDS expansion.
+# On the nRF52832 the microapp size is 4 pages
+# On the nRF52840 we have more pages, so allow for 4 apps.
+# For now though, set number of pages to 4, as the code doesn't work yet for multiple microapps.
+# Page size is 0x1000.
+# 0xEF000 - (4+8+16)*0x1000 = 0xD3000
+FLASH_MICROAPP_BASE=0xD3000
+FLASH_MICROAPP_PAGES=4
+
+# We can use up to the P2P DFU page: FLASH_MICROAPP_BASE - 0x1000.
+# The maximum size of the app is then 0xD3000 - 0x1000 - 0x26000 = 0xAC000
+APPLICATION_START_ADDRESS=0x26000
+APPLICATION_MAX_LENGTH=0xAC000
+
+# RAM base can just be obtained through running bluenet with logging enabled and pen it down.
+# The remaining amount is 256 kB minus the result (0x40000 - 0x2AA8 = 0x3D558).
+RAM_R1_BASE=0x20002AA8
+RAM_APPLICATION_AMOUNT=0x3D558
+
+# Reserve some extra space for the bootloader, for debugging.
+BOOTLOADER_START_ADDRESS=0xEF000
+BOOTLOADER_LENGTH=0xF000
+
+
+# This setting is defined in nrf_dfu_types.h. Here we predefine it so it is available to the wider code base.
+# This is the mbr settings address for the nRF52840-QFAA.
+CS_BOOTLOADER_SETTINGS_ADDRESS=0xFF000
+
+# This setting is defined in nrf_dfu_types.h. Here we predefine it so it is available to the wider code base.
+# This is the mbr settings address for the nRF52840-QFAA.
+CS_MBR_PARAMS_PAGE_ADDRESS=0xFE000
+
+# MAX 
+UART_BAUDRATE=57600

--- a/source/include/boards/cs_BoardMap.h
+++ b/source/include/boards/cs_BoardMap.h
@@ -243,6 +243,7 @@ static cs_uicr_data_t mapBoardToUicrData(uint32_t boardVersion) {
 		case PCA10036:
 		case PCA10040:
 		case PCA10056:
+		case PCA10059:
 		case PCA10100: {
 			data.productRegionFamily.fields.productType   = PRODUCT_DEV_BOARD;
 			data.productRegionFamily.fields.region        = 0xFF;

--- a/source/include/boards/cs_PCA10059.h
+++ b/source/include/boards/cs_PCA10059.h
@@ -1,0 +1,54 @@
+/*
+ * Author: Crownstone Team
+ * Copyright: Crownstone (https://crownstone.rocks)
+ * Date: Jan 25, 2022
+ * License: LGPLv3+, Apache License 2.0, and/or MIT (triple-licensed)
+ */
+
+#pragma once
+
+#include <cfg/cs_Boards.h>
+#include <cfg/cs_DeviceTypes.h>
+
+/* ********************************************************************************************************************
+ * Dev board
+ * *******************************************************************************************************************/
+
+/**
+ * This is the dongle with a nRF52840 on it.
+ *
+ * Note that the JTAG connector doesn't have UART pins broken out. From what I know, there are also no GPIOs available
+ * over USB at first sight. Of course, that's not true because the USB bootloader uses USB. However, it is not easy
+ * to just configure RX and TX pins here and use USB.
+ *
+ * Check components/boards/pca10059.h for pin info.
+ *
+ * More resources:
+ * https://devzone.nordicsemi.com/guides/short-range-guides/b/getting-started/posts/nrf52840-dongle-programming-tutorial
+ * https://infocenter.nordicsemi.com/pdf/nRF52_DK_User_Guide_v1.2.pdf
+ *
+ * Note that the nRF52840 chip on the dongle hardware is configured in high voltage mode.
+ *
+ * The firmware must set REGOUT0 to 3 V (this is not yet implemented).
+ */
+void asPca10059(boards_config_t* config) {
+	config->pinDimmer                       = PIN_NONE;
+	config->pinRx                           = 8;
+	config->pinTx                           = 6;
+
+	config->flags.enableUart                = true;
+	config->flags.enableLeds                = true;
+	// Check this
+	//config->flags.usesNfcPins               = true;
+	
+	config->pinButton[0]                    = GetGpioPin(1,6);
+	
+	config->pinLed[0]                       = 6;
+	config->pinLed[1]                       = 8;
+	config->pinLed[2]                       = GetGpioPin(1, 9);
+	config->pinLed[3]                       = 12;
+
+	config->deviceType                      = DEVICE_CROWNSTONE_USB;
+	config->minTxPower                      = -40;
+	config->scanWindowUs                    = config->scanIntervalUs;
+}

--- a/source/include/cfg/cs_Boards.h
+++ b/source/include/cfg/cs_Boards.h
@@ -41,6 +41,8 @@ extern "C" {
 #define PCA10100 42
 // Nordic dev board for the nRF52840
 #define PCA10056 43
+// Nordic USB dongle for the nRF52840
+#define PCA10059 44
 
 // Rectangular beacons from China.
 #define GUIDESTONE 100
@@ -167,66 +169,70 @@ uint8_t GetGpioPin(uint8_t major, uint8_t minor);
  * Configure pins for control relays, IGBTs, LEDs, UART, current sensing, etc.
  */
 typedef struct {
-	// The hardware board type (number).
+	//! The hardware board type (number).
 	uint32_t hardwareBoard;
 
-	// GPIO pin to control the IGBTs.
+	//! GPIO pin to control the IGBTs.
 	uint8_t pinDimmer;
 
-	// GPIO pin to enable the IGBT circuit.
+	//! GPIO pin to enable the IGBT circuit.
 	uint8_t pinEnableDimmer;
 
-	// GPIO to debug the relay: turns on when relay is turned on, and vice versa. Inverted when LEDs are inverted.
+	//! GPIO to debug the relay: turns on when relay is turned on, and vice versa. Inverted when LEDs are inverted.
 	uint8_t pinRelayDebug;
 
-	// GPIO pin to switch the relay on.
+	//! GPIO pin to switch the relay on.
 	uint8_t pinRelayOn;
 
-	// GPIO pin to switch the relay off.
+	//! GPIO pin to switch the relay off.
 	uint8_t pinRelayOff;
 
-	// Analog input pins to read the current with different gains (if present).
+	//! Analog input pins to read the current with different gains (if present).
 	uint8_t pinAinCurrent[GAIN_COUNT];
 
-	// Analog input pins to read the voltage with different gains (if present).
+	//! Analog input pins to read the voltage with different gains (if present).
 	uint8_t pinAinVoltage[GAIN_COUNT];
 
-	// Analog input pins to read the voltage after the load with different gains (if present).
+	//! Analog input pins to read the voltage after the load with different gains (if present).
 	uint8_t pinAinVoltageAfterLoad[GAIN_COUNT];
 
-	// Analog input pin to read 'zero' / offset (to be used for both current and voltage measurements).
+	//! Analog input pin to read 'zero' / offset (to be used for both current and voltage measurements).
 	uint8_t pinAinZeroRef;
 
-	// Analog input pin to read the dimmer temperature.
+	//! Analog input pin to read the dimmer temperature.
 	uint8_t pinAinDimmerTemp;
 
-	// Analog input pin to measure EARTH
+	//! Analog input pin to measure EARTH
 	uint8_t pinAinEarth;
 
-	// GPIO pin to get zero-crossing information for current.
+	//! GPIO pin to get zero-crossing information for current.
 	uint8_t pinCurrentZeroCrossing;
 
-	// GPIO pin to get zero-crossing information for voltage.
+	//! GPIO pin to get zero-crossing information for voltage.
 	uint8_t pinVoltageZeroCrossing;
 
-	// GPIO pin to receive UART.
+	//! GPIO pin to receive UART.
 	uint8_t pinRx;
 
-	// GPIO pin to send UART.
+	//! GPIO pin to send UART.
 	uint8_t pinTx;
 
-	// GPIO pins that can be used as GPIO by the user, for example microapps.
+	//! GPIO pins that can be used as GPIO by the user, for example microapps.
 	uint8_t pinGpio[GPIO_INDEX_COUNT];
 
-	// GPIO pins of buttons (on dev. kit).
+	//! GPIO pins of buttons (on dev. kit).
 	uint8_t pinButton[BUTTON_COUNT];
 
-	// GPIO pins of LEDs.
+	//! GPIO pins of LEDs.
 	uint8_t pinLed[LED_COUNT];
 
+	//! JTAG / SWD pins for flashing.
 	struct __attribute__((__packed__)) {
+		//! Chip select pin
 		uint8_t cs;
+		//! Clock pin
 		uint8_t clk;
+		//! Data pins
 		uint8_t dio[4];
 	} pinFlash;
 
@@ -235,11 +241,11 @@ typedef struct {
 		//! True if the dimmer is inverted (setting gpio high turns dimmer off).
 		bool dimmerInverted : 1;
 
-		// True if the board should have UART enabled by default.
+		//! True if the board should have UART enabled by default.
 		bool enableUart : 1;
 
-		// True if the board has LEDs that should be enabled by default.
-		// Some boards do have LEDs, but cannot deliver enough power when also listening (scanning / meshing).
+		//! True if the board has LEDs that should be enabled by default.
+		//! Some boards do have LEDs, but cannot deliver enough power when also listening (scanning / meshing).
 		bool enableLeds : 1;
 
 		//! True if LED is off when GPIO is set high.
@@ -248,20 +254,20 @@ typedef struct {
 		//! True if the temperature sensor of the dimmer is inverted (NTC).
 		bool dimmerTempInverted : 1;
 
-		// True if the NFC pins (p0.09 and p0.10) are used as GPIO.
+		//! True if the NFC pins (p0.09 and p0.10) are used as GPIO.
 		bool usesNfcPins : 1;
 
-		// True if the Crownstone has a more accurate power measurement.
+		//! True if the Crownstone has a more accurate power measurement.
 		bool hasAccuratePowerMeasurement : 1;
 
-		// True if the Crownstone can try dimming at boot, because it has an accurate enough power measurement,
-		// and a lower startup time of the dimmer circuit.
+		//! True if the Crownstone can try dimming at boot, because it has an accurate enough power measurement,
+		//! and a lower startup time of the dimmer circuit.
 		bool canTryDimmingOnBoot : 1;
 
-		// True if the Crownstone can dim immediately after a warm boot.
+		//! True if the Crownstone can dim immediately after a warm boot.
 		bool canDimOnWarmBoot : 1;
 
-		// True if the dimmer can be on when the pins are floating (during boot).
+		//! True if the dimmer can be on when the pins are floating (during boot).
 		bool dimmerOnWhenPinsFloat : 1;
 	} flags;
 

--- a/source/include/cfg/cs_Config.h
+++ b/source/include/cfg/cs_Config.h
@@ -224,12 +224,13 @@ static const uint8_t DEFAULT_DIM_VALUE           = 40;
  * supplies a maximum and a minimum wanted interval. The connection interval must be between 7.5 ms and 4 s.
  * See https://devzone.nordicsemi.com/question/161154/minimum-connection-interval/
  *
- * If the connection interval is equal to RF_SDH_BLE_GAP_EVENT_LENGTH, the connection can take up 100% of the radio time, leaving none for the mesh.
+ * If the connection interval is equal to NRF_SDH_BLE_GAP_EVENT_LENGTH, the connection can take up 100% of the radio time, leaving none for the mesh.
  * The shortest timeslot the mesh uses is 3.8ms (TIMESLOT_BASE_LENGTH_SHORT_US),
- * so we could consider setting MIN_CONNECTION_INTERVAL to 4 * 1.25 ms larger than RF_SDH_BLE_GAP_EVENT_LENGTH.
+ * so we could consider setting MIN_CONNECTION_INTERVAL to 4 * 1.25 ms larger than NRF_SDH_BLE_GAP_EVENT_LENGTH.
+ * NRF_SDH_BLE_GAP_EVENT_LENGTH is by default equal to 6.
  */
 #define MIN_CONNECTION_INTERVAL                  6   // In units of 1.25ms.
-#define MAX_CONNECTION_INTERVAL                  16  // In units of 1.25ms.
+#define MAX_CONNECTION_INTERVAL                  16  // In units of 1.25ms. (20 ms)
 
 /*
  * This timeout determines the timeout from the last data exchange till a link is considered lost. A Central will not

--- a/source/include/processing/cs_PowerSampling.h
+++ b/source/include/processing/cs_PowerSampling.h
@@ -18,6 +18,9 @@
 
 typedef void (*ps_zero_crossing_cb_t)();
 
+/**
+ * Sample power.
+ */
 class PowerSampling : EventListener {
 public:
 	//! Gets a static singleton (no dynamic memory allocation)

--- a/source/src/ble/cs_Stack.cpp
+++ b/source/src/ble/cs_Stack.cpp
@@ -844,7 +844,7 @@ void Stack::onIncomingConnected(const ble_evt_t* p_ble_evt) {
 }
 
 void Stack::onIncomingDisconnected(const ble_evt_t* p_ble_evt) {
-	LOGi("Device disconnected");
+	LOGi("Incoming device disconnect");
 
 	for (Service* service : _services) {
 		service->onBleEvent(p_ble_evt);

--- a/source/src/cfg/cs_Boards.c
+++ b/source/src/cfg/cs_Boards.c
@@ -46,6 +46,7 @@
 #include <boards/cs_GuideStone.h>
 #include <boards/cs_PCA10040.h>
 #include <boards/cs_PCA10056.h>
+#include <boards/cs_PCA10059.h>
 #include <boards/cs_UsbDongle.h>
 #include <cfg/cs_AutoConfig.h>
 #include <cfg/cs_Boards.h>
@@ -196,6 +197,7 @@ cs_ret_code_t configure_board_from_hardware_board(uint32_t hardwareBoard, boards
 		case PCA10036:
 		case PCA10040: asPca10040(config); break;
 		case PCA10056: asPca10056(config); break;
+		case PCA10059: asPca10059(config); break;
 		case PCA10100:
 			// should not be
 			asPca10040(config);


### PR DESCRIPTION
Initial commit for PCA10059. Note the remarks in the `cs_PCA10059.h` file. 

# UART

+ You'll need to delve into the USB bootloader code or the schematics to find out if there's a way to set TX/RX in such way that it can be used to communicate as with the ordinary USB dongle.

# Updates

+ There's no Segger chip on-board. It's not clear to me if the USB bootloader can overwrite itself.
+ If the USB bootloader cannot overwrite itself, it is not obvious how to run the BLE bootloader we usually use. You will have to place it somewhere else than the default location.
+ Alternatively you can try to adapt the USB bootloader so that it can be used together with bluenet. However, updates OTA won't work in that case. Firmware updates over USB would then be the way to go. There is some communication from the bluenet bootloader towards bluenet in an IPC section. This needs to be taken care of so that the bluenet code will work fine without any more info on the bootloader.
